### PR TITLE
[S1-M1-03] Add ProtectedRoute, AuthContext placeholder, and full rout…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useAuth } from './context/AuthContext';
 import CustomersPage from './pages/CustomersPage';
 import SalesPage from './pages/SalesPage';
 import ProductsPage from './pages/ProductsPage';
@@ -7,8 +8,11 @@ import DeletedCustomersPage from './pages/DeletedCustomersPage';
 import AuthCallbackPage from './pages/AuthCallbackPage';
 
 function ProtectedRoute({ children }) {
-  // Auth logic will be wired in Sprint 2 by M4
-  // For now just renders the page
+  const { currentUser, loading } = useAuth();
+
+  if (loading) return <div>Loading...</div>;
+  if (!currentUser) return <Navigate to="/login" />;
+
   return children;
 }
 
@@ -17,6 +21,7 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Navigate to="/customers" />} />
+        <Route path="/login" element={<div>Login - coming soon</div>} />
         <Route path="/customers" element={<ProtectedRoute><CustomersPage /></ProtectedRoute>} />
         <Route path="/sales" element={<ProtectedRoute><SalesPage /></ProtectedRoute>} />
         <Route path="/products" element={<ProtectedRoute><ProductsPage /></ProtectedRoute>} />

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,17 @@
+import { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  // Placeholder — M4 will replace this with real Supabase auth in their PR
+  const [currentUser] = useState(null);
+  const [loading] = useState(false);
+
+  return (
+    <AuthContext.Provider value={{ currentUser, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { AuthProvider } from './context/AuthContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## What changed
- Updated ProtectedRoute to check for authenticated user via useAuth()
- Created placeholder AuthContext (to be replaced by M4 in their PR)
- Wrapped App with AuthProvider in main.jsx
- Added /login placeholder route
- Unauthenticated users now redirect to /login

## How to test
1. npm run dev
2. Visit localhost:5173 — should redirect to /login
3. Visit localhost:5173/customers — should redirect to /login
4. Visit localhost:5173/auth/callback — should show Loading...

## Checklist
- [x] Forked from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code