### PR TITLE
[S1-M4-01] Add AuthContext with session listener, login guard, and currentUser state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import AuthCallbackPage from './pages/AuthCallbackPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import AppShell from './components/AppShell';
+import { AuthProvider } from './context/AuthContext';
 
 function ProtectedRoute({ children }) {
   const { currentUser, loading, signOut } = useAuth();
@@ -23,18 +24,20 @@ function ProtectedRoute({ children }) {
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Navigate to="/customers" />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<RegisterPage />} />
-        <Route path="/customers" element={<ProtectedRoute><CustomersPage /></ProtectedRoute>} />
-        <Route path="/sales" element={<ProtectedRoute><SalesPage /></ProtectedRoute>} />
-        <Route path="/products" element={<ProtectedRoute><ProductsPage /></ProtectedRoute>} />
-        <Route path="/admin" element={<ProtectedRoute><AdminPage /></ProtectedRoute>} />
-        <Route path="/deleted-customers" element={<ProtectedRoute><DeletedCustomersPage /></ProtectedRoute>} />
-        <Route path="/auth/callback" element={<AuthCallbackPage />} />
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Navigate to="/customers" />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/customers" element={<ProtectedRoute><CustomersPage /></ProtectedRoute>} />
+          <Route path="/sales" element={<ProtectedRoute><SalesPage /></ProtectedRoute>} />
+          <Route path="/products" element={<ProtectedRoute><ProductsPage /></ProtectedRoute>} />
+          <Route path="/admin" element={<ProtectedRoute><AdminPage /></ProtectedRoute>} />
+          <Route path="/deleted-customers" element={<ProtectedRoute><DeletedCustomersPage /></ProtectedRoute>} />
+          <Route path="/auth/callback" element={<AuthCallbackPage />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   );
 }

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,17 +1,79 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from "react";
+import { supabase } from "../lib/supabase";
 
 const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
-  // Placeholder — M4 will replace this with real Supabase auth in their PR
-  const [currentUser] = useState(null);
-  const [loading] = useState(false);
+  const [currentUser, setCurrentUser] = useState(null);
+  const [loading, setLoading]         = useState(true);
+  const [error, setError]             = useState(null);
+
+  useEffect(() => {
+    // Get the session that already exists (e.g. on page refresh)
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        handleSession(session);
+      } else {
+        setLoading(false);
+      }
+    });
+
+    // Listen for sign-in / sign-out events
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      async (event, session) => {
+        if (session) {
+          await handleSession(session);
+        } else {
+          setCurrentUser(null);
+          setLoading(false);
+        }
+      }
+    );
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  async function handleSession(session) {
+    setLoading(true);
+    setError(null);
+
+    const { data: userRow, error: dbError } = await supabase
+      .from("user")
+      .select("record_status, user_type, username")
+      .eq("userId", session.user.id)
+      .single();
+
+    if (dbError || !userRow) {
+      // User row doesn't exist yet (trigger may still be running)
+      setError("Account setup incomplete. Please try again.");
+      await supabase.auth.signOut();
+      setLoading(false);
+      return;
+    }
+
+    if (userRow.record_status !== "ACTIVE") {
+      await supabase.auth.signOut();
+      setError("Your account is pending activation by a Sales Manager.");
+      setLoading(false);
+      return;
+    }
+
+    setCurrentUser({ ...session.user, ...userRow });
+    setLoading(false);
+  }
+
+  async function signOut() {
+    await supabase.auth.signOut();
+    setCurrentUser(null);
+  }
 
   return (
-    <AuthContext.Provider value={{ currentUser, loading }}>
+    <AuthContext.Provider value={{ currentUser, loading, error, setError, signOut }}>
       {children}
     </AuthContext.Provider>
   );
 }
 
-export const useAuth = () => useContext(AuthContext);
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
What changed:
- Created AuthContext.jsx with onAuthStateChange listener
- Added login guard that blocks INACTIVE accounts
- Exposed currentUser, loading, error, and signOut via context
- Filled in supabase.js with Supabase client initialization
- Wrapped App.jsx with AuthProvider

Why:
Required foundation for all auth-dependent components.

How to test:
- npm run dev — app loads and redirects to /login without errors