### PR TITLE
[S1-M3-02] fix: added user SELECT policy

### DIFF
--- a/db/migrations/02_rights_seed.sql
+++ b/db/migrations/02_rights_seed.sql
@@ -185,6 +185,10 @@ CREATE POLICY umr_read_own ON "UserModule_Rights"
     FOR SELECT TO authenticated
     USING (userId = auth.uid()::text);
 
+CREATE POLICY user_read_own ON "user"
+    FOR SELECT TO authenticated
+    USING (userId = auth.uid()::text);
+
 
 -- =============================================================================
 -- SECTION 4: SEED — MODULES (4 rows)


### PR DESCRIPTION
## What changed
- Added missing `SELECT` policy `user_read_own` on the `"user"` table in `02_rights_seed.sql`
- RLS was already enabled on `"user"` in the original PR-02 but no corresponding SELECT policy was created — authenticated users could not read their own row
- Policy restricts reads to the caller's own row only: `USING (userId = auth.uid()::text)`
- Policy was already applied manually to the live Supabase project by M4 as a temporary unblock — this PR makes it official and tracked in the repo

## How to test
1. In Supabase SQL Editor, confirm the policy exists:
```sql
SELECT policyname, cmd, qual
FROM pg_policies
WHERE tablename = 'user'
  AND policyname = 'user_read_own';
```
2. Confirm an authenticated user can read their own row but not others:
```sql
-- Should return 1 row (your own)
SELECT * FROM "user" WHERE userId = auth.uid()::text;

-- Should return 0 rows (blocked by RLS)
SELECT * FROM "user" WHERE userId != auth.uid()::text;
```
3. Confirm M4's login guard can now resolve `record_status` on sign-in without a 406 or empty response from Supabase

## Checklist
- [x] Forked from dev
- [x] Policy matches the temporary fix M4 already deployed — no divergence
- [x] No other policies added or modified
- [x] Migration file updated and committed to `/db/migrations/`
- [x] No `.env` files committed
- [x] Flagged in description that live DB and migration files are now back in sync