### PR TITLE
[S1-M4-02] Wire signIn and signUp to Login and Register pages

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,17 +1,89 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from "react";
+import { supabase } from "../lib/supabase";
 
 const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
-  // Placeholder — M4 will replace this with real Supabase auth in their PR
-  const [currentUser] = useState(null);
-  const [loading] = useState(false);
+  const [currentUser, setCurrentUser] = useState(null);
+  const [loading, setLoading]         = useState(true);
+  const [error, setError]             = useState(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) handleSession(session);
+      else setLoading(false);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      async (event, session) => {
+        if (session) await handleSession(session);
+        else {
+          setCurrentUser(null);
+          setLoading(false);
+        }
+      }
+    );
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  async function handleSession(session) {
+    setLoading(true);
+    setError(null);
+
+    const { data: userRow, error: dbError } = await supabase
+      .from("user")
+      .select("record_status, user_type, username")
+      .eq("userId", session.user.id)
+      .single();
+
+    if (dbError || !userRow) {
+      setError("Account setup incomplete. Please try again.");
+      await supabase.auth.signOut();
+      setLoading(false);
+      return;
+    }
+
+    if (userRow.record_status !== "ACTIVE") {
+      await supabase.auth.signOut();
+      setError("Your account is pending activation by a Sales Manager.");
+      setLoading(false);
+      return;
+    }
+
+    setCurrentUser({ ...session.user, ...userRow });
+    setLoading(false);
+  }
+
+  async function signIn(email, password) {
+    setError(null);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) setError(error.message);
+  }
+
+  async function signUp(firstName, lastName, username, email, password) {
+    setError(null);
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { firstName, lastName, username } },
+    });
+    if (error) setError(error.message);
+    else setError("Account created! Wait for an admin to activate it before logging in.");
+  }
+
+  async function signOut() {
+    await supabase.auth.signOut();
+    setCurrentUser(null);
+  }
 
   return (
-    <AuthContext.Provider value={{ currentUser, loading }}>
+    <AuthContext.Provider value={{ currentUser, loading, error, setError, signIn, signUp, signOut }}>
       {children}
     </AuthContext.Provider>
   );
 }
 
-export const useAuth = () => useContext(AuthContext);
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -10,13 +10,18 @@
 //   loading                       → boolean — auth loading state
 
 import { useState } from "react";
+import { useAuth } from "../context/AuthContext";
+import { useNavigate } from "react-router-dom";
 
-export default function LoginPage({
-  onEmailLogin = async () => {},
-  onGoogleLogin = () => {},
-  authError = "",
-  loading = false,
-}) {
+export default function LoginPage() {
+  const { signIn, loading, error: authError } = useAuth();
+  const navigate = useNavigate();
+
+  const onEmailLogin = async (email, password) => {
+    await signIn(email, password);
+  };
+
+  const onGoogleLogin = () => {};  // Google OAuth wired in Task 3
   const [email, setEmail]     = useState("");
   const [password, setPassword] = useState("");
   const [errors, setErrors]   = useState({});

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -10,13 +10,16 @@
 //   loading             → boolean — auth loading state
 
 import { useState } from "react";
+import { useAuth } from "../context/AuthContext";
 
-export default function RegisterPage({
-  onEmailRegister = async () => {},
-  onGoogleRegister = () => {},
-  authError = "",
-  loading = false,
-}) {
+export default function RegisterPage() {
+  const { signUp, loading, error: authError } = useAuth();
+
+  const onEmailRegister = async (firstName, lastName, username, email, password) => {
+    await signUp(firstName, lastName, username, email, password);
+  };
+
+  const onGoogleRegister = () => {};  // Google OAuth wired in Task 3
   const [form, setForm] = useState({
     firstName: "",
     lastName: "",


### PR DESCRIPTION
What changed:
- Added signIn() and signUp() functions to AuthContext
- Wired signIn() to LoginPage via useAuth() hook
- Wired signUp() to RegisterPage via useAuth() hook
- Both pages now pull loading and error state from AuthContext

Why:
Connects M2's UI forms to Supabase email auth.

How to test:
- npm run dev
- Go to /register and create a new account → success message appears
- Go to /login with an INACTIVE account → login guard blocks with error message

Blockers:
- Login guard fully testable after M3's SELECT policy fix on "user"
  table (now merged in PR #37)
- provision_new_user() trigger deployed in db/trigger-provision-user branch