### PR TITLE
[S1-M3-02] fix: correct userid casing in user table RLS policies

### DIFF
--- a/db/migrations/02_rights_seed.sql
+++ b/db/migrations/02_rights_seed.sql
@@ -179,15 +179,15 @@ CREATE POLICY rights_read_all ON rights
 
 CREATE POLICY user_module_read_own ON user_module
     FOR SELECT TO authenticated
-    USING (userId = auth.uid()::text);
+    USING (userid = auth.uid()::text);
 
 CREATE POLICY umr_read_own ON "UserModule_Rights"
     FOR SELECT TO authenticated
-    USING (userId = auth.uid()::text);
+    USING (userid = auth.uid()::text);
 
 CREATE POLICY user_read_own ON "user"
     FOR SELECT TO authenticated
-    USING (userId = auth.uid()::text);
+    USING (userid = auth.uid()::text);
 
 
 -- =============================================================================


### PR DESCRIPTION
## What changed
- Corrected column reference from `userId` to `userid` in all RLS policies that reference the column on the `"user"`, `user_module`, and `"UserModule_Rights"` tables
- PostgreSQL folds unquoted column names to lowercase at storage time — `userId` defined in `CREATE TABLE` is stored and referenced as `userid`
- The original `user_read_own` policy silently failed instead of erroring, blocking M4's login guard from reading the caller's own row
- Also corrected `user_module_read_own` and `umr_read_own` policies which had the same casing issue
- All three corrected policies were already deployed manually to the live Supabase project by M4 as a temporary unblock — this PR makes them official and tracked in the repo

## How to test
1. In Supabase SQL Editor, confirm the column is stored as lowercase:
```sql
SELECT column_name
FROM information_schema.columns
WHERE table_schema = 'public'
  AND table_name   = 'user'
  AND column_name  = 'userid';
-- Expected: returns 'userid', not 'userId'
```
2. Confirm all three corrected policies exist with the right casing:
```sql
SELECT policyname, cmd, qual
FROM pg_policies
WHERE schemaname = 'public'
  AND policyname IN ('user_read_own', 'user_module_read_own', 'umr_read_own')
ORDER BY policyname;
-- Expected: 3 rows, qual column shows 'userid' not 'userId'
```
3. Confirm M4's login guard resolves `record_status` without hanging or returning empty

## Checklist
- [x] Forked from dev
- [x] All three affected policies corrected in `02_rights_seed.sql`
- [x] Policies match what M4 already deployed manually — no divergence
- [x] No other policies added or modified
- [x] Migration file updated and committed to `/db/migrations/`
- [x] No `.env` files committed
- [x] Flagged in description that live DB and migration files are now back in sync