### PR TITLE
[S2-M1-01] feat/customer-api — Add customer service functions

### DIFF
--- a/src/services/customerService.js
+++ b/src/services/customerService.js
@@ -1,0 +1,89 @@
+import { supabase } from '../lib/supabase';
+
+// Generates a stamp string for audit trail
+function makeStamp(action, userId) {
+  const now = new Date().toISOString();
+  return `${action} by ${userId} on ${now}`;
+}
+
+// Get customers — ACTIVE only for USER, all for ADMIN/SUPERADMIN
+export async function getCustomers(userType) {
+  let query = supabase
+    .from('customer')
+    .select('*')
+    .order('custno');
+
+  if (userType === 'USER') {
+    query = query.eq('record_status', 'ACTIVE');
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return data;
+}
+
+// Add a new customer
+export async function addCustomer(customerData, userId) {
+  const { data, error } = await supabase
+    .from('customer')
+    .insert([
+      {
+        ...customerData,
+        record_status: 'ACTIVE',
+        stamp: makeStamp('CREATED', userId),
+      },
+    ])
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+// Update an existing customer's details
+export async function updateCustomer(custno, updates, userId) {
+  const { data, error } = await supabase
+    .from('customer')
+    .update({
+      ...updates,
+      stamp: makeStamp('UPDATED', userId),
+    })
+    .eq('custno', custno)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+// Soft delete — sets record_status to INACTIVE (NO hard delete ever)
+export async function softDeleteCustomer(custno, userId) {
+  const { data, error } = await supabase
+    .from('customer')
+    .update({
+      record_status: 'INACTIVE',
+      stamp: makeStamp('DEACTIVATED', userId),
+    })
+    .eq('custno', custno)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+// Recover a soft-deleted customer — sets record_status back to ACTIVE
+export async function recoverCustomer(custno, userId) {
+  const { data, error } = await supabase
+    .from('customer')
+    .update({
+      record_status: 'ACTIVE',
+      stamp: makeStamp('REACTIVATED', userId),
+    })
+    .eq('custno', custno)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}


### PR DESCRIPTION
## What changed
- Added src/services/customerService.js with 5 customer service functions
- getCustomers(userType) filters ACTIVE only when userType = 'USER'
- softDeleteCustomer() sets record_status to INACTIVE, never hard deletes
- All mutating functions write an audit stamp on every change

## How to test
1. Call getCustomers('USER') — should return ACTIVE records only
2. Call getCustomers('ADMIN') — should return all records including INACTIVE
3. Call softDeleteCustomer() — confirm record_status becomes INACTIVE, row is never deleted

## Checklist
- [ ] Branched from dev
- [ ] App runs without errors
- [ ] No .env files committed
- [ ] No console.log in code