### PR TITLE
[S2-M1-02] feat/sales-product-api — Add read-only service functions

### DIFF
--- a/src/services/salesProductService.js
+++ b/src/services/salesProductService.js
@@ -1,0 +1,69 @@
+import { supabase } from '../lib/supabase';
+
+// Get all sales transactions for a specific customer
+export async function getSalesByCustomer(custNo) {
+  const { data, error } = await supabase
+    .from('sales')
+    .select('transNo, salesDate, empNo')
+    .eq('custNo', custNo)
+    .order('salesDate', { ascending: false });
+
+  if (error) throw error;
+  return data;
+}
+
+// Get all line items for a specific transaction
+export async function getSalesDetail(transNo) {
+  const { data, error } = await supabase
+    .from('salesDetail')
+    .select(`
+      transNo,
+      quantity,
+      product (
+        prodCode,
+        description,
+        unit
+      )
+    `)
+    .eq('transNo', transNo);
+
+  if (error) throw error;
+  return data;
+}
+
+// Get all products (read-only)
+export async function getProducts() {
+  const { data, error } = await supabase
+    .from('product')
+    .select('*')
+    .order('prodCode');
+
+  if (error) throw error;
+  return data;
+}
+
+// Get full price history for a specific product
+export async function getPriceHistory(prodCode) {
+  const { data, error } = await supabase
+    .from('priceHist')
+    .select('effDate, unitPrice')
+    .eq('prodCode', prodCode)
+    .order('effDate', { ascending: false });
+
+  if (error) throw error;
+  return data;
+}
+
+// Get the current (latest) price for a specific product
+export async function getCurrentPrice(prodCode) {
+  const { data, error } = await supabase
+    .from('priceHist')
+    .select('unitPrice, effDate')
+    .eq('prodCode', prodCode)
+    .order('effDate', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error) throw error;
+  return data;
+}


### PR DESCRIPTION
## What changed
- Added src/services/salesProductService.js with 5 read-only service functions
- getSalesByCustomer(custNo) — fetches all transactions for a customer
- getSalesDetail(transNo) — fetches line items joined with product info
- getProducts() — fetches full product catalogue
- getPriceHistory(prodCode) — fetches full price history for a product
- getCurrentPrice(prodCode) — fetches latest price entry for a product
- Zero write operations exist for any of these tables

## How to test
1. Call getSalesByCustomer() with a valid custNo — should return transactions only, no write calls
2. Call getSalesDetail() with a valid transNo — should return line items with product description
3. Confirm no insert/update/delete calls exist anywhere in this file

## Checklist
- [ ] Branched from dev
- [ ] App runs without errors
- [ ] No .env files committed
- [ ] No console.log in code