### PR TITLE
[S2-M1-04] feat/route-guard-deleted — Block USER accounts from /deleted-customers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,6 +49,32 @@ function ProtectedRoute() {
   )
 }
 
+// AdminRoute — extends ProtectedRoute by also blocking USER accounts.
+// Used for routes that require ADMIN or SUPERADMIN access.
+// USER accounts are redirected to /customers.
+function AdminRoute() {
+  const { currentUser, loading, signOut } = useAuth()
+
+  // Show a spinner while the login guard is running
+  if (loading) return <LoadingScreen />
+
+  // Not authenticated — redirect to login
+  if (!currentUser) return <Navigate to="/login" replace />
+
+  // USER accounts are not allowed — redirect to customers
+  if (currentUser.user_type === 'USER') return <Navigate to="/customers" replace />
+
+  // ADMIN or SUPERADMIN — render AppShell wrapping the matched child route
+  return (
+    <AppShell
+      currentUser={currentUser}
+      onLogout={signOut}
+    >
+      <Outlet />
+    </AppShell>
+  )
+}
+
 // Simple full-screen loading spinner shown while AuthContext resolves
 function LoadingScreen() {
   return (
@@ -91,18 +117,22 @@ export default function App() {
       <UserRightsProvider>
         <BrowserRouter>
           <Routes>
-
             {/* ── Public routes ────────────────────────────────────────── */}
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
             <Route path="/auth/callback" element={<AuthCallbackPage />} />
 
-            {/* ── Protected routes — all wrapped by AppShell ───────────── */}
+            {/* ── Protected routes — all authenticated users ──────────── */}
             <Route element={<ProtectedRoute />}>
               <Route path="/customers" element={<CustomersPage />} />
               <Route path="/sales" element={<SalesPage />} />
               <Route path="/products" element={<ProductsPage />} />
               <Route path="/admin" element={<AdminPage />} />
+            </Route>
+
+            {/* ── Admin-only routes — ADMIN and SUPERADMIN only ───────── */}
+            {/* USER accounts are redirected to /customers               */}
+            <Route element={<AdminRoute />}>
               <Route path="/deleted-customers" element={<DeletedCustomersPage />} />
             </Route>
 


### PR DESCRIPTION
## What changed
- Added AdminRoute component in App.jsx that checks user_type after authentication
- Moved /deleted-customers out of ProtectedRoute and into its own AdminRoute block
- USER accounts attempting to access /deleted-customers are redirected to /customers
- ADMIN and SUPERADMIN accounts access /deleted-customers normally

## How to test
1. Log in as USER — navigate to /deleted-customers — should redirect to /customers
2. Log in as ADMIN — navigate to /deleted-customers — should load normally
3. Log in as SUPERADMIN — navigate to /deleted-customers — should load normally
4. Unauthenticated user — navigate to /deleted-customers — should redirect to /login

## Checklist
- [x] Branched from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code