### PR TITLE
[S2-M2-02] Add AddCustomerModal, EditCustomerModal, and SoftDeleteConfirmDialog

### DIFF
--- a/src/components/AddCustomerModal.jsx
+++ b/src/components/AddCustomerModal.jsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import { addCustomer } from '../services/customerService'
+import { useAuth } from '../context/AuthContext'
+
+export default function AddCustomerModal({ onClose, onSuccess }) {
+  const { currentUser } = useAuth()
+  const [form, setForm] = useState({ custno: '', custname: '', address: '', payterm: 'COD' })
+  const [errors, setErrors] = useState({})
+  const [touched, setTouched] = useState({})
+  const [loading, setLoading] = useState(false)
+  const [serverError, setServerError] = useState(null)
+
+  const css = `
+    .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 24px; }
+    .modal-box { background: #fff; border-radius: 14px; border: 1px solid #e5e7eb; width: 100%; max-width: 480px; overflow: hidden; }
+    .modal-header { padding: 20px 24px 16px; border-bottom: 1px solid #f3f4f6; display: flex; justify-content: space-between; align-items: center; }
+    .modal-title { font-size: 16px; font-weight: 600; color: #111827; margin: 0; }
+    .modal-close { background: none; border: none; font-size: 20px; color: #9ca3af; cursor: pointer; padding: 0; line-height: 1; }
+    .modal-close:hover { color: #374151; }
+    .modal-body { padding: 20px 24px; display: flex; flex-direction: column; gap: 16px; }
+    .modal-footer { padding: 16px 24px; border-top: 1px solid #f3f4f6; display: flex; justify-content: flex-end; gap: 10px; background: #f9fafb; }
+    .field-group { display: flex; flex-direction: column; gap: 6px; }
+    .field-label { font-size: 13px; font-weight: 600; color: #374151; }
+    .field-input { height: 40px; padding: 0 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 13px; color: #111827; outline: none; width: 100%; box-sizing: border-box; }
+    .field-input:focus { border-color: #93c5fd; box-shadow: 0 0 0 3px rgba(59,130,246,0.1); }
+    .field-input.has-error { border-color: #f87171; box-shadow: 0 0 0 3px rgba(239,68,68,0.1); }
+    .field-select { height: 40px; padding: 0 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 13px; color: #111827; outline: none; width: 100%; box-sizing: border-box; background: #fff; }
+    .field-select:focus { border-color: #93c5fd; }
+    .field-error { font-size: 12px; color: #dc2626; margin: 0; }
+    .server-error { background: #fff1f2; border: 1px solid #fecdd3; border-radius: 8px; padding: 10px 14px; font-size: 13px; color: #9f1239; }
+    .btn-cancel { padding: 8px 18px; border-radius: 8px; border: 1px solid #e5e7eb; background: #fff; color: #374151; font-size: 13px; font-weight: 500; cursor: pointer; }
+    .btn-cancel:hover { background: #f9fafb; }
+    .btn-submit { padding: 8px 18px; border-radius: 8px; border: none; background: #1d4ed8; color: #fff; font-size: 13px; font-weight: 500; cursor: pointer; }
+    .btn-submit:hover { background: #1e40af; }
+    .btn-submit:disabled { opacity: 0.6; cursor: not-allowed; }
+  `
+
+  function validate(f) {
+    const e = {}
+    if (!f.custno.trim()) e.custno = 'Customer number is required.'
+    else if (!/^C\d{4}$/.test(f.custno.trim())) e.custno = 'Format must be C0001–C9999.'
+    if (!f.custname.trim()) e.custname = 'Customer name is required.'
+    else if (f.custname.trim().length > 20) e.custname = 'Max 20 characters.'
+    if (f.address.length > 50) e.address = 'Max 50 characters.'
+    return e
+  }
+
+  function handleChange(field, value) {
+    const next = { ...form, [field]: value }
+    setForm(next)
+    if (touched[field]) setErrors(validate(next))
+  }
+
+  function handleBlur(field) {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+    setErrors(validate(form))
+  }
+
+  async function handleSubmit() {
+    const allTouched = { custno: true, custname: true, address: true, payterm: true }
+    setTouched(allTouched)
+    const validationErrors = validate(form)
+    setErrors(validationErrors)
+    if (Object.keys(validationErrors).length > 0) return
+
+    setLoading(true)
+    setServerError(null)
+    try {
+      await addCustomer(
+        { custno: form.custno.trim(), custname: form.custname.trim(), address: form.address.trim(), payterm: form.payterm },
+        currentUser?.userid || currentUser?.id
+      )
+      onSuccess()
+      onClose()
+    } catch (err) {
+      setServerError(err.message || 'Failed to add customer. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <style>{css}</style>
+      <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+        <div className="modal-box">
+          <div className="modal-header">
+            <h2 className="modal-title">Add Customer</h2>
+            <button className="modal-close" onClick={onClose}>×</button>
+          </div>
+
+          <div className="modal-body">
+            {serverError && <div className="server-error">{serverError}</div>}
+
+            <div className="field-group">
+              <label className="field-label">Customer No. <span style={{ color: '#dc2626' }}>*</span></label>
+              <input
+                className={`field-input ${errors.custno && touched.custno ? 'has-error' : ''}`}
+                type="text"
+                placeholder="C0001"
+                value={form.custno}
+                onChange={(e) => handleChange('custno', e.target.value)}
+                onBlur={() => handleBlur('custno')}
+              />
+              {errors.custno && touched.custno && <p className="field-error">{errors.custno}</p>}
+            </div>
+
+            <div className="field-group">
+              <label className="field-label">Customer Name <span style={{ color: '#dc2626' }}>*</span></label>
+              <input
+                className={`field-input ${errors.custname && touched.custname ? 'has-error' : ''}`}
+                type="text"
+                placeholder="e.g. Globus Medical, Inc"
+                value={form.custname}
+                onChange={(e) => handleChange('custname', e.target.value)}
+                onBlur={() => handleBlur('custname')}
+              />
+              {errors.custname && touched.custname && <p className="field-error">{errors.custname}</p>}
+            </div>
+
+            <div className="field-group">
+              <label className="field-label">Address</label>
+              <input
+                className={`field-input ${errors.address && touched.address ? 'has-error' : ''}`}
+                type="text"
+                placeholder="Full address"
+                value={form.address}
+                onChange={(e) => handleChange('address', e.target.value)}
+                onBlur={() => handleBlur('address')}
+              />
+              {errors.address && touched.address && <p className="field-error">{errors.address}</p>}
+            </div>
+
+            <div className="field-group">
+              <label className="field-label">Payment Term <span style={{ color: '#dc2626' }}>*</span></label>
+              <select
+                className="field-select"
+                value={form.payterm}
+                onChange={(e) => handleChange('payterm', e.target.value)}
+              >
+                <option value="COD">COD — Cash on Delivery</option>
+                <option value="30D">30D — 30-day terms</option>
+                <option value="45D">45D — 45-day terms</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="modal-footer">
+            <button className="btn-cancel" onClick={onClose}>Cancel</button>
+            <button className="btn-submit" onClick={handleSubmit} disabled={loading}>
+              {loading ? 'Saving…' : 'Add Customer'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/EditCustomerModal.jsx
+++ b/src/components/EditCustomerModal.jsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+import { updateCustomer } from '../services/customerService'
+import { useAuth } from '../context/AuthContext'
+
+export default function EditCustomerModal({ customer, onClose, onSuccess }) {
+  const { currentUser } = useAuth()
+  const [form, setForm] = useState({
+    custname: customer.custname || '',
+    address: customer.address || '',
+    payterm: customer.payterm || 'COD',
+  })
+  const [errors, setErrors] = useState({})
+  const [touched, setTouched] = useState({})
+  const [loading, setLoading] = useState(false)
+  const [serverError, setServerError] = useState(null)
+
+  const css = `
+    .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 24px; }
+    .modal-box { background: #fff; border-radius: 14px; border: 1px solid #e5e7eb; width: 100%; max-width: 480px; overflow: hidden; }
+    .modal-header { padding: 20px 24px 16px; border-bottom: 1px solid #f3f4f6; display: flex; justify-content: space-between; align-items: center; }
+    .modal-title { font-size: 16px; font-weight: 600; color: #111827; margin: 0; }
+    .modal-custno { font-size: 12px; color: #9ca3af; font-family: monospace; margin: 2px 0 0; }
+    .modal-close { background: none; border: none; font-size: 20px; color: #9ca3af; cursor: pointer; padding: 0; line-height: 1; }
+    .modal-close:hover { color: #374151; }
+    .modal-body { padding: 20px 24px; display: flex; flex-direction: column; gap: 16px; }
+    .modal-footer { padding: 16px 24px; border-top: 1px solid #f3f4f6; display: flex; justify-content: flex-end; gap: 10px; background: #f9fafb; }
+    .field-group { display: flex; flex-direction: column; gap: 6px; }
+    .field-label { font-size: 13px; font-weight: 600; color: #374151; }
+    .field-input { height: 40px; padding: 0 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 13px; color: #111827; outline: none; width: 100%; box-sizing: border-box; }
+    .field-input:focus { border-color: #93c5fd; box-shadow: 0 0 0 3px rgba(59,130,246,0.1); }
+    .field-input.has-error { border-color: #f87171; box-shadow: 0 0 0 3px rgba(239,68,68,0.1); }
+    .field-select { height: 40px; padding: 0 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 13px; color: #111827; outline: none; width: 100%; box-sizing: border-box; background: #fff; }
+    .field-select:focus { border-color: #93c5fd; }
+    .field-error { font-size: 12px; color: #dc2626; margin: 0; }
+    .server-error { background: #fff1f2; border: 1px solid #fecdd3; border-radius: 8px; padding: 10px 14px; font-size: 13px; color: #9f1239; }
+    .readonly-field { height: 40px; padding: 0 12px; border: 1px solid #f3f4f6; border-radius: 8px; font-size: 13px; color: #6b7280; background: #f9fafb; display: flex; align-items: center; font-family: monospace; }
+    .btn-cancel { padding: 8px 18px; border-radius: 8px; border: 1px solid #e5e7eb; background: #fff; color: #374151; font-size: 13px; font-weight: 500; cursor: pointer; }
+    .btn-cancel:hover { background: #f9fafb; }
+    .btn-submit { padding: 8px 18px; border-radius: 8px; border: none; background: #1d4ed8; color: #fff; font-size: 13px; font-weight: 500; cursor: pointer; }
+    .btn-submit:hover { background: #1e40af; }
+    .btn-submit:disabled { opacity: 0.6; cursor: not-allowed; }
+  `
+
+  function validate(f) {
+    const e = {}
+    if (!f.custname.trim()) e.custname = 'Customer name is required.'
+    else if (f.custname.trim().length > 20) e.custname = 'Max 20 characters.'
+    if (f.address.length > 50) e.address = 'Max 50 characters.'
+    return e
+  }
+
+  function handleChange(field, value) {
+    const next = { ...form, [field]: value }
+    setForm(next)
+    if (touched[field]) setErrors(validate(next))
+  }
+
+  function handleBlur(field) {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+    setErrors(validate(form))
+  }
+
+  async function handleSubmit() {
+    const allTouched = { custname: true, address: true, payterm: true }
+    setTouched(allTouched)
+    const validationErrors = validate(form)
+    setErrors(validationErrors)
+    if (Object.keys(validationErrors).length > 0) return
+
+    setLoading(true)
+    setServerError(null)
+    try {
+      await updateCustomer(
+        customer.custno,
+        { custname: form.custname.trim(), address: form.address.trim(), payterm: form.payterm },
+        currentUser?.userid || currentUser?.id
+      )
+      onSuccess()
+      onClose()
+    } catch (err) {
+      setServerError(err.message || 'Failed to update customer. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <style>{css}</style>
+      <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+        <div className="modal-box">
+          <div className="modal-header">
+            <div>
+              <h2 className="modal-title">Edit Customer</h2>
+              <p className="modal-custno">{customer.custno}</p>
+            </div>
+            <button className="modal-close" onClick={onClose}>×</button>
+          </div>
+
+          <div className="modal-body">
+            {serverError && <div className="server-error">{serverError}</div>}
+
+            <div className="field-group">
+              <label className="field-label">Customer No.</label>
+              <div className="readonly-field">{customer.custno}</div>
+            </div>
+
+            <div className="field-group">
+              <label className="field-label">Customer Name <span style={{ color: '#dc2626' }}>*</span></label>
+              <input
+                className={`field-input ${errors.custname && touched.custname ? 'has-error' : ''}`}
+                type="text"
+                value={form.custname}
+                onChange={(e) => handleChange('custname', e.target.value)}
+                onBlur={() => handleBlur('custname')}
+              />
+              {errors.custname && touched.custname && <p className="field-error">{errors.custname}</p>}
+            </div>
+
+            <div className="field-group">
+              <label className="field-label">Address</label>
+              <input
+                className={`field-input ${errors.address && touched.address ? 'has-error' : ''}`}
+                type="text"
+                value={form.address}
+                onChange={(e) => handleChange('address', e.target.value)}
+                onBlur={() => handleBlur('address')}
+              />
+              {errors.address && touched.address && <p className="field-error">{errors.address}</p>}
+            </div>
+
+            <div className="field-group">
+              <label className="field-label">Payment Term <span style={{ color: '#dc2626' }}>*</span></label>
+              <select
+                className="field-select"
+                value={form.payterm}
+                onChange={(e) => handleChange('payterm', e.target.value)}
+              >
+                <option value="COD">COD — Cash on Delivery</option>
+                <option value="30D">30D — 30-day terms</option>
+                <option value="45D">45D — 45-day terms</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="modal-footer">
+            <button className="btn-cancel" onClick={onClose}>Cancel</button>
+            <button className="btn-submit" onClick={handleSubmit} disabled={loading}>
+              {loading ? 'Saving…' : 'Save Changes'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/SoftDeleteConfirmDialog.jsx
+++ b/src/components/SoftDeleteConfirmDialog.jsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+import { softDeleteCustomer } from '../services/customerService'
+import { useAuth } from '../context/AuthContext'
+
+export default function SoftDeleteConfirmDialog({ customer, onClose, onSuccess }) {
+  const { currentUser } = useAuth()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const css = `
+    .dialog-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 1000; padding: 24px; }
+    .dialog-box { background: #fff; border-radius: 14px; border: 1px solid #e5e7eb; width: 100%; max-width: 420px; overflow: hidden; }
+    .dialog-header { padding: 20px 24px 0; }
+    .dialog-icon { width: 44px; height: 44px; border-radius: 50%; background: #fee2e2; display: flex; align-items: center; justify-content: center; margin-bottom: 14px; font-size: 20px; }
+    .dialog-title { font-size: 16px; font-weight: 600; color: #111827; margin: 0 0 8px; }
+    .dialog-body { padding: 0 24px 20px; }
+    .dialog-desc { font-size: 13px; color: #6b7280; line-height: 1.6; margin: 0 0 12px; }
+    .dialog-name { font-size: 13px; font-weight: 600; color: #111827; background: #f9fafb; border: 1px solid #f3f4f6; border-radius: 8px; padding: 10px 14px; margin-bottom: 12px; display: flex; justify-content: space-between; }
+    .dialog-name-mono { font-family: monospace; font-size: 12px; color: #9ca3af; }
+    .dialog-warning { background: #fff7ed; border: 1px solid #fed7aa; border-radius: 8px; padding: 10px 14px; font-size: 12px; color: #9a3412; line-height: 1.5; }
+    .dialog-error { background: #fff1f2; border: 1px solid #fecdd3; border-radius: 8px; padding: 10px 14px; font-size: 13px; color: #9f1239; margin-top: 12px; }
+    .dialog-footer { padding: 16px 24px; border-top: 1px solid #f3f4f6; display: flex; justify-content: flex-end; gap: 10px; background: #f9fafb; }
+    .btn-cancel { padding: 8px 18px; border-radius: 8px; border: 1px solid #e5e7eb; background: #fff; color: #374151; font-size: 13px; font-weight: 500; cursor: pointer; }
+    .btn-cancel:hover { background: #f9fafb; }
+    .btn-delete { padding: 8px 18px; border-radius: 8px; border: none; background: #dc2626; color: #fff; font-size: 13px; font-weight: 500; cursor: pointer; }
+    .btn-delete:hover { background: #b91c1c; }
+    .btn-delete:disabled { opacity: 0.6; cursor: not-allowed; }
+  `
+
+  async function handleConfirm() {
+    setLoading(true)
+    setError(null)
+    try {
+      await softDeleteCustomer(
+        customer.custno,
+        currentUser?.userid || currentUser?.id
+      )
+      onSuccess()
+      onClose()
+    } catch (err) {
+      setError(err.message || 'Failed to delete customer. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <style>{css}</style>
+      <div className="dialog-overlay" onClick={(e) => e.target === e.currentTarget && onClose()}>
+        <div className="dialog-box">
+          <div className="dialog-header">
+            <div className="dialog-icon">🗑</div>
+            <h2 className="dialog-title">Delete Customer?</h2>
+          </div>
+
+          <div className="dialog-body">
+            <p className="dialog-desc">
+              You are about to soft-delete this customer. They will be hidden from regular users but can be recovered by an Admin.
+            </p>
+
+            <div className="dialog-name">
+              <span>{customer.custname}</span>
+              <span className="dialog-name-mono">{customer.custno}</span>
+            </div>
+
+            <div className="dialog-warning">
+              This does not permanently delete any data. The customer's sales history remains intact and visible to Admins.
+            </div>
+
+            {error && <div className="dialog-error">{error}</div>}
+          </div>
+
+          <div className="dialog-footer">
+            <button className="btn-cancel" onClick={onClose}>Cancel</button>
+            <button className="btn-delete" onClick={handleConfirm} disabled={loading}>
+              {loading ? 'Deleting…' : 'Yes, delete'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/pages/CustomersPage.jsx
+++ b/src/pages/CustomersPage.jsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react'
 import { getCustomers } from '../services/customerService'
 import { useAuth } from '../context/AuthContext'
+import AddCustomerModal from '../components/AddCustomerModal'
+import EditCustomerModal from '../components/EditCustomerModal'
+import SoftDeleteConfirmDialog from '../components/SoftDeleteConfirmDialog'
 
 export default function CustomersPage() {
   const { currentUser } = useAuth()
@@ -12,23 +15,26 @@ export default function CustomersPage() {
   const [search, setSearch] = useState('')
   const [paytermFilter, setPaytermFilter] = useState('')
 
+  const [showAdd, setShowAdd] = useState(false)
+  const [editTarget, setEditTarget] = useState(null)
+  const [deleteTarget, setDeleteTarget] = useState(null)
+
   const showStamp = userType === 'ADMIN' || userType === 'SUPERADMIN'
 
-  useEffect(() => {
-    async function fetchCustomers() {
-      setLoading(true)
-      setError(null)
-      try {
-        const data = await getCustomers(userType)
-        setCustomers(data || [])
-      } catch {
-        setError('Failed to load customers. Please try again.')
-      } finally {
-        setLoading(false)
-      }
+  async function fetchCustomers() {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await getCustomers(userType)
+      setCustomers(data || [])
+    } catch {
+      setError('Failed to load customers. Please try again.')
+    } finally {
+      setLoading(false)
     }
-    fetchCustomers()
-  }, [userType])
+  }
+
+  useEffect(() => { fetchCustomers() }, [userType])
 
   const filtered = customers.filter((c) => {
     const matchesSearch =
@@ -38,7 +44,6 @@ export default function CustomersPage() {
     return matchesSearch && matchesPayterm
   })
 
-  /* ── Injected styles ── */
   const css = `
     .cms-page { padding: 28px 32px; font-family: sans-serif; max-width: 1100px; margin: 0 auto; }
     .cms-topbar { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 24px; }
@@ -52,7 +57,6 @@ export default function CustomersPage() {
     .cms-search { width: 100%; box-sizing: border-box; padding: 8px 12px 8px 34px; border: 1px solid #e5e7eb; border-radius: 8px; font-size: 13px; color: #111827; outline: none; }
     .cms-search:focus { border-color: #93c5fd; box-shadow: 0 0 0 3px rgba(59,130,246,0.1); }
     .cms-select { padding: 8px 12px; border: 1px solid #e5e7eb; border-radius: 8px; font-size: 13px; color: #111827; background: #fff; outline: none; }
-    .cms-select:focus { border-color: #93c5fd; }
     .cms-card { background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden; }
     .cms-table { width: 100%; border-collapse: collapse; font-size: 13px; }
     .cms-table thead { background: #f9fafb; }
@@ -68,38 +72,46 @@ export default function CustomersPage() {
     .badge-active { background: #d1fae5; color: #065f46; }
     .badge-inactive { background: #fee2e2; color: #991b1b; }
     .badge-dot { width: 5px; height: 5px; border-radius: 50%; display: inline-block; }
-    .badge-dot-active { background: #059669; }
-    .badge-dot-inactive { background: #dc2626; }
     .stamp-cell { font-size: 11px; color: #9ca3af; font-family: monospace; max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .btn-edit { padding: 4px 10px; border-radius: 6px; border: 1px solid #e5e7eb; font-size: 12px; cursor: pointer; background: #fff; color: #374151; margin-right: 6px; }
-    .btn-edit:hover { background: #f9fafb; border-color: #d1d5db; }
+    .btn-edit:hover { background: #f9fafb; }
     .btn-del { padding: 4px 10px; border-radius: 6px; border: 1px solid #fecaca; font-size: 12px; cursor: pointer; background: #fff; color: #dc2626; }
     .btn-del:hover { background: #fef2f2; }
     .cms-footer { display: flex; justify-content: space-between; align-items: center; padding: 10px 14px; border-top: 1px solid #f3f4f6; font-size: 12px; color: #9ca3af; }
     .cms-empty { text-align: center; padding: 56px 24px; color: #9ca3af; font-size: 14px; }
     .cms-error { text-align: center; padding: 56px 24px; color: #dc2626; font-size: 14px; }
-    .cms-loading { text-align: center; padding: 56px 24px; color: #6b7280; font-size: 14px; }
   `
 
-  if (loading) return (
-    <>
-      <style>{css}</style>
-      <div className="cms-loading">Loading customers…</div>
-    </>
-  )
-
-  if (error) return (
-    <>
-      <style>{css}</style>
-      <div className="cms-error">{error}</div>
-    </>
-  )
+  if (loading) return <><style>{css}</style><div className="cms-empty">Loading customers…</div></>
+  if (error) return <><style>{css}</style><div className="cms-error">{error}</div></>
 
   return (
     <>
       <style>{css}</style>
-      <div className="cms-page">
 
+      {/* Modals */}
+      {showAdd && (
+        <AddCustomerModal
+          onClose={() => setShowAdd(false)}
+          onSuccess={fetchCustomers}
+        />
+      )}
+      {editTarget && (
+        <EditCustomerModal
+          customer={editTarget}
+          onClose={() => setEditTarget(null)}
+          onSuccess={fetchCustomers}
+        />
+      )}
+      {deleteTarget && (
+        <SoftDeleteConfirmDialog
+          customer={deleteTarget}
+          onClose={() => setDeleteTarget(null)}
+          onSuccess={fetchCustomers}
+        />
+      )}
+
+      <div className="cms-page">
         {/* Header */}
         <div className="cms-topbar">
           <div>
@@ -107,7 +119,9 @@ export default function CustomersPage() {
             <p className="cms-sub">{customers.length} total records</p>
           </div>
           {/* Add button — rights gating wired by M4 */}
-          <button className="cms-add-btn">+ Add customer</button>
+          <button className="cms-add-btn" onClick={() => setShowAdd(true)}>
+            + Add customer
+          </button>
         </div>
 
         {/* Search & Filter */}
@@ -158,25 +172,21 @@ export default function CustomersPage() {
                       <td className="cms-custno">{c.custno}</td>
                       <td className="cms-custname">{c.custname}</td>
                       <td className="cms-address" title={c.address}>{c.address}</td>
-                      <td>
-                        <span className="payterm-pill">{c.payterm}</span>
-                      </td>
+                      <td><span className="payterm-pill">{c.payterm}</span></td>
                       <td>
                         <span className={`badge ${c.record_status === 'ACTIVE' ? 'badge-active' : 'badge-inactive'}`}>
-                          <span className={`badge-dot ${c.record_status === 'ACTIVE' ? 'badge-dot-active' : 'badge-dot-inactive'}`} />
+                          <span className="badge-dot" style={{ background: c.record_status === 'ACTIVE' ? '#059669' : '#dc2626' }} />
                           {c.record_status === 'ACTIVE' ? 'Active' : 'Inactive'}
                         </span>
                       </td>
                       {showStamp && (
-                        <td className="stamp-cell" title={c.stamp || ''}>
-                          {c.stamp || '—'}
-                        </td>
+                        <td className="stamp-cell" title={c.stamp || ''}>{c.stamp || '—'}</td>
                       )}
                       <td>
                         {/* Rights gating wired by M4 */}
-                        <button className="btn-edit">Edit</button>
+                        <button className="btn-edit" onClick={() => setEditTarget(c)}>Edit</button>
                         {userType === 'SUPERADMIN' && (
-                          <button className="btn-del">Delete</button>
+                          <button className="btn-del" onClick={() => setDeleteTarget(c)}>Delete</button>
                         )}
                       </td>
                     </tr>
@@ -189,7 +199,6 @@ export default function CustomersPage() {
             </>
           )}
         </div>
-
       </div>
     </>
   )


### PR DESCRIPTION
What changed:
- AddCustomerModal: form with custno, custname, address, payterm dropdown
  with client-side validation (format check, required fields, max length)
- EditCustomerModal: pre-filled form for updating custname, address, payterm
  custno is read-only, cannot be changed
- SoftDeleteConfirmDialog: confirmation dialog showing customer name and
  number before soft-delete, with warning that data is recoverable
- All three modals wired into CustomersPage with state toggles
- Modals close on backdrop click or Cancel button
- All three call the correct customerService functions on submit
- onSuccess() triggers fetchCustomers() to refresh the table after changes

How to test:
- Log in as SUPERADMIN
- Click + Add customer — modal opens, validate empty submit shows errors,
  valid submit calls addCustomer()
- Click Edit on any row — modal opens pre-filled with that customer's data
- Click Delete on any row — dialog shows customer name and custno
- Click outside any modal — it closes
- Click Cancel on any modal — it closes

Note: Actual DB writes pending M3's RLS policies (Sprint 2 M3 tasks).
Modal logic and UI are complete and verified.

