### PR TITLE
[S2-M4-01] feat/rights-context — Implement real UserRightsContext with Supabase query

### DIFF
--- a/src/context/UserRightsContext.jsx
+++ b/src/context/UserRightsContext.jsx
@@ -1,60 +1,92 @@
 import { createContext, useContext, useState, useEffect } from 'react'
 import { useAuth } from './AuthContext'
-
-// ── Placeholder UserRightsContext ─────────────────────────────────────────────
-// This is a scaffold created by M1 so App.jsx can wrap the provider without
-// crashing while M4 builds the real implementation.
-//
-// M4 should REPLACE this file entirely with the full UserRightsContext that:
-//   - Queries all 9 UserModule_Rights rows on login
-//   - Stores them as { CUST_VIEW:1, CUST_ADD:0, ... }
-//   - Exposes them via useRights()
-// ─────────────────────────────────────────────────────────────────────────────
+import { supabase } from '../lib/supabase'
 
 const UserRightsContext = createContext(null)
 
 export function UserRightsProvider({ children }) {
-  const { currentUser } = useAuth()
-  const [rights, setRights] = useState({
-    CUST_VIEW:  0,
-    CUST_ADD:   0,
-    CUST_EDIT:  0,
-    CUST_DEL:   0,
-    SALES_VIEW: 0,
-    SD_VIEW:    0,
-    PROD_VIEW:  0,
-    PRICE_VIEW: 0,
-    ADM_USER:   0,
-  })
-  const [rightsLoading, setRightsLoading] = useState(false)
+    const { currentUser } = useAuth()
 
-  // TODO (M4): replace this useEffect with a real Supabase query
-  // that loads all 9 UserModule_Rights rows for currentUser
-  useEffect(() => {
-    if (!currentUser) {
-      setRights({
-        CUST_VIEW:  0,
-        CUST_ADD:   0,
-        CUST_EDIT:  0,
-        CUST_DEL:   0,
+    const [rights, setRights] = useState({
+        CUST_VIEW: 0,
+        CUST_ADD: 0,
+        CUST_EDIT: 0,
+        CUST_DEL: 0,
         SALES_VIEW: 0,
-        SD_VIEW:    0,
-        PROD_VIEW:  0,
+        SD_VIEW: 0,
+        PROD_VIEW: 0,
         PRICE_VIEW: 0,
-        ADM_USER:   0,
-      })
-    }
-  }, [currentUser])
+        ADM_USER: 0,
+    })
+    const [rightsLoading, setRightsLoading] = useState(false)
 
-  return (
-    <UserRightsContext.Provider value={{ rights, rightsLoading }}>
-      {children}
-    </UserRightsContext.Provider>
-  )
+    useEffect(() => {
+        // Clear rights when no user is logged in
+        if (!currentUser) {
+            setRights({
+                CUST_VIEW: 0,
+                CUST_ADD: 0,
+                CUST_EDIT: 0,
+                CUST_DEL: 0,
+                SALES_VIEW: 0,
+                SD_VIEW: 0,
+                PROD_VIEW: 0,
+                PRICE_VIEW: 0,
+                ADM_USER: 0,
+            })
+            return
+        }
+
+        // Load all 9 rights for the current user from UserModule_Rights
+        async function loadRights() {
+            setRightsLoading(true)
+            try {
+                const { data, error } = await supabase
+                    .from('UserModule_Rights')
+                    .select('rightcode, right_value')
+                    .eq('userid', currentUser.id)
+
+                if (error) throw error
+
+                // Build rights map from the returned rows
+                const map = {
+                    CUST_VIEW: 0,
+                    CUST_ADD: 0,
+                    CUST_EDIT: 0,
+                    CUST_DEL: 0,
+                    SALES_VIEW: 0,
+                    SD_VIEW: 0,
+                    PROD_VIEW: 0,
+                    PRICE_VIEW: 0,
+                    ADM_USER: 0,
+                }
+
+                data.forEach((row) => {
+                    if (row.rightcode in map) {
+                        map[row.rightcode] = row.right_value
+                    }
+                })
+
+                setRights(map)
+            } catch (err) {
+                console.error('Failed to load user rights:', err)
+            } finally {
+                setRightsLoading(false)
+            }
+        }
+
+        loadRights()
+    }, [currentUser])
+
+    return (
+        <UserRightsContext.Provider value={{ rights, rightsLoading }}>
+            {children}
+        </UserRightsContext.Provider>
+    )
 }
 
 export function useRights() {
-  const context = useContext(UserRightsContext)
-  if (!context) throw new Error('useRights must be used inside UserRightsProvider')
-  return context
+    const context = useContext(UserRightsContext)
+    if (!context) throw new Error('useRights must be used inside UserRightsProvider')
+    return context
 }


### PR DESCRIPTION
## What changed
- Replaced placeholder UserRightsContext with real implementation
- Queries all 9 rows from UserModule_Rights table on login
- Builds rights map: { CUST_VIEW:1, CUST_ADD:1, ... } from returned rows
- Clears all rights to 0 on logout
- Exposes rights and rightsLoading via useRights() hook

## Fixes noted during implementation
- Used lowercase rightcode column name to match PostgreSQL storage
- Used lowercase userid column name in .eq() filter

## How to test
1. Log in as SUPERADMIN — all 9 rights should be 1
2. Log in as USER — only VIEW rights should be 1, all CRUD rights should be 0
3. Log out — rights should reset to all 0
4. No console errors after login

## Checklist
- [x] Branched from dev
- [x] App runs without errors
- [x] No .env files committed
- [x] No console.log in code