### PR TITLE
[S2-M1] fix/lowercase-salespage — Fix camelCase column names in SalesPage

### DIFF
--- a/src/pages/SalesPage.jsx
+++ b/src/pages/SalesPage.jsx
@@ -132,13 +132,13 @@ export default function SalesPage() {
                 <tbody>
                   {sales.map((s) => (
                     <tr
-                      key={s.transNo}
-                      className={selectedTrans === s.transNo ? 'selected' : ''}
-                      onClick={() => handleSelectTransaction(s.transNo)}
+                      key={s.transno}
+                      className={selectedTrans === s.transno ? 'selected' : ''}
+                      onClick={() => handleSelectTransaction(s.transno)}
                     >
-                      <td className="sp-mono">{s.transNo}</td>
-                      <td>{s.salesDate}</td>
-                      <td className="sp-mono">{s.empNo}</td>
+                      <td className="sp-mono">{s.transno}</td>
+                      <td>{s.salesdate}</td>
+                      <td className="sp-mono">{s.empno}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -175,7 +175,7 @@ export default function SalesPage() {
                 <tbody>
                   {detail.map((d, i) => (
                     <tr key={i}>
-                      <td className="sp-mono">{d.product?.prodCode}</td>
+                      <td className="sp-mono">{d.product?.prodcode}</td>
                       <td>{d.product?.description}</td>
                       <td>
                         <span className="sp-badge">{d.product?.unit}</span>


### PR DESCRIPTION
## What changed
- Fixed SalesPage.jsx to use lowercase column names matching PostgreSQL storage
- transNo → transno, salesDate → salesdate, empNo → empno
- prodCode → prodcode in line items detail panel

## How to test
1. Navigate to Sales page
2. Search for C0001 — transactions should display correctly
3. Click a transaction — line items should show with product code and description
4. No console errors

## Checklist
- [ ] Branched from dev
- [ ] App runs without errors
- [ ] No .env files committed
- [ ] No console.log in code