### PR TITLE
[S2-M1] fix/lowercase-customerdetail — Fix camelCase column names in CustomerDetailPage

### DIFF
--- a/src/pages/CustomerDetailPage.jsx
+++ b/src/pages/CustomerDetailPage.jsx
@@ -186,7 +186,7 @@ export default function CustomerDetailPage() {
                   <tbody>
                     {detail.map((d, i) => (
                       <tr key={i}>
-                        <td className="cd-mono">{d.product?.prodCode}</td>
+                        <td className="cd-mono">{d.product?.prodcode}</td>
                         <td style={{ fontWeight: 500 }}>{d.product?.description}</td>
                         <td><span className="sd-unit">{d.product?.unit}</span></td>
                         <td style={{ textAlign: 'right', fontWeight: 600 }}>{d.quantity}</td>
@@ -263,13 +263,13 @@ export default function CustomerDetailPage() {
                 <tbody>
                   {sales.map((s) => (
                     <tr
-                      key={s.transNo}
-                      className={selectedTrans === s.transNo ? 'selected' : ''}
-                      onClick={() => handleSelectTransaction(s.transNo)}
+                      key={s.transno}
+                      className={selectedTrans === s.transno ? 'selected' : ''}
+                      onClick={() => handleSelectTransaction(s.transno)}
                     >
-                      <td className="cd-mono">{s.transNo}</td>
-                      <td>{s.salesDate}</td>
-                      <td className="cd-mono">{s.empNo}</td>
+                      <td className="cd-mono">{s.transno}</td>
+                      <td>{s.salesdate}</td>
+                      <td className="cd-mono">{s.empno}</td>
                       <td>
                         <button className="cd-view-btn">View items →</button>
                       </td>

--- a/src/pages/SalesPage.jsx
+++ b/src/pages/SalesPage.jsx
@@ -132,13 +132,13 @@ export default function SalesPage() {
                 <tbody>
                   {sales.map((s) => (
                     <tr
-                      key={s.transNo}
-                      className={selectedTrans === s.transNo ? 'selected' : ''}
-                      onClick={() => handleSelectTransaction(s.transNo)}
+                      key={s.transno}
+                      className={selectedTrans === s.transno ? 'selected' : ''}
+                      onClick={() => handleSelectTransaction(s.transno)}
                     >
-                      <td className="sp-mono">{s.transNo}</td>
-                      <td>{s.salesDate}</td>
-                      <td className="sp-mono">{s.empNo}</td>
+                      <td className="sp-mono">{s.transno}</td>
+                      <td>{s.salesdate}</td>
+                      <td className="sp-mono">{s.empno}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -175,7 +175,7 @@ export default function SalesPage() {
                 <tbody>
                   {detail.map((d, i) => (
                     <tr key={i}>
-                      <td className="sp-mono">{d.product?.prodCode}</td>
+                      <td className="sp-mono">{d.product?.prodcode}</td>
                       <td>{d.product?.description}</td>
                       <td>
                         <span className="sp-badge">{d.product?.unit}</span>


### PR DESCRIPTION
## What changed
- Fixed CustomerDetailPage.jsx to use lowercase column names matching PostgreSQL storage
- transNo → transno, salesDate → salesdate, empNo → empno in sales history table
- prodCode → prodcode in sales detail modal line items

## How to test
1. Click any customer name from the Customers page
2. Sales History panel should show transactions with Trans No., Date, Emp No.
3. Click View items → on any transaction — modal should show line items with product code and description

## Checklist
- [ ] Branched from dev
- [ ] App runs without errors
- [ ] No .env files committed
- [ ] No console.log in code