### PR TITLE
[S3-M1-01] feat/admin-api — Add Admin Module API with SUPERADMIN Guard

### DIFF
--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -1,0 +1,48 @@
+import { supabase } from '../lib/supabase';
+
+export async function getUsers() {
+  const { data, error } = await supabase
+    .from('"user"')
+    .select('userId, username, email, user_type, record_status')
+    .order('user_type');
+  if (error) throw error;
+  return data;
+}
+
+export async function activateUser(userId) {
+  const { data: target, error: fetchError } = await supabase
+    .from('"user"')
+    .select('user_type')
+    .eq('userId', userId)
+    .single();
+
+  if (fetchError) throw fetchError;
+  if (target?.user_type === 'SUPERADMIN') {
+    throw new Error('SUPERADMIN accounts cannot be modified.');
+  }
+
+  const { error } = await supabase
+    .from('"user"')
+    .update({ record_status: 'ACTIVE' })
+    .eq('userId', userId);
+  if (error) throw error;
+}
+
+export async function deactivateUser(userId) {
+  const { data: target, error: fetchError } = await supabase
+    .from('"user"')
+    .select('user_type')
+    .eq('userId', userId)
+    .single();
+
+  if (fetchError) throw fetchError;
+  if (target?.user_type === 'SUPERADMIN') {
+    throw new Error('SUPERADMIN accounts cannot be modified.');
+  }
+
+  const { error } = await supabase
+    .from('"user"')
+    .update({ record_status: 'INACTIVE' })
+    .eq('userId', userId);
+  if (error) throw error;
+}


### PR DESCRIPTION
## What changed
- Created `src/services/adminService.js` with three Admin Module API functions.
- `getUsers()` fetches all users (`userId`, `username`, `email`, `user_type`, `record_status`) ordered by `user_type`.
- `activateUser(userId)` sets `record_status` to `ACTIVE` after verifying the target is not `SUPERADMIN`.
- `deactivateUser(userId)` sets `record_status` to `INACTIVE` after verifying the target is not `SUPERADMIN`.
- All three functions throw an explicit error if a `SUPERADMIN` row is targeted, enforcing protection at the API layer before RLS even fires.

## How to test
- Log in as **SUPERADMIN** → navigate to Admin Module → confirm user list loads.
- Attempt to call `activateUser()` or `deactivateUser()` on the SUPERADMIN row → confirm error is thrown.
- Log in as **ADMIN** → confirm Admin Module page is not accessible (`ADM_USER = 0`).

## Checklist
- [ ] Branched from `dev`
- [ ] App runs without errors
- [ ] No `.env` files committed
- [ ] No `console.log` in code