### PR TITLE
[S3-M1-02] feat/reports-api — Add CMS Reports API (Customer Summary, Top Customers, Product Revenue)

### DIFF
--- a/src/services/reportsService.js
+++ b/src/services/reportsService.js
@@ -1,0 +1,29 @@
+import { supabase } from '../lib/supabase';
+
+export async function getCustomerSalesSummary() {
+  const { data, error } = await supabase
+    .from('customer_sales_summary')
+    .select('custno, custname, payterm, record_status, totalTransactions, totalSpend, lastSaleDate')
+    .order('totalSpend', { ascending: false });
+  if (error) throw error;
+  return data;
+}
+
+export async function getTopCustomers() {
+  const { data, error } = await supabase
+    .from('customer_sales_summary')
+    .select('custno, custname, totalTransactions, totalSpend, lastSaleDate')
+    .order('totalSpend', { ascending: false })
+    .limit(10);
+  if (error) throw error;
+  return data;
+}
+
+export async function getProductRevenue() {
+  const { data, error } = await supabase
+    .from('product_revenue')
+    .select('prodCode, description, unit, totalQtySold, totalRevenue')
+    .order('totalRevenue', { ascending: false });
+  if (error) throw error;
+  return data;
+}


### PR DESCRIPTION
## What changed
- Created `src/services/reportsService.js` with three CMS report API functions.
- `getCustomerSalesSummary()` fetches all customers with their total transactions, total spend, and last sale date from the `customer_sales_summary` view, ordered by `totalSpend` descending.
- `getTopCustomers()` fetches the top 10 customers by total spend from the same view.
- `getProductRevenue()` fetches all products with their total quantity sold and total revenue from the `product_revenue` view, ordered by `totalRevenue` descending.

## How to test
- Log in as **SUPERADMIN** → confirm `getCustomerSalesSummary()` returns all customers with correct totals.
- Confirm `getTopCustomers()` returns exactly 10 rows ordered by spend descending.
- Confirm `getProductRevenue()` returns all products ordered by revenue descending.
- Verify no write operations exist anywhere in `reportsService.js`.

## Checklist
- [ ] Branched from `dev`
- [ ] App runs without errors
- [ ] No `.env` files committed
- [ ] No `console.log` in code