### PR TITLE
[S3-M4-01] feat/rights-admin-module — ADM_USER Sidebar Gating with Admin Tooltip

### DIFF
--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -24,7 +24,7 @@ const NAV_ITEMS = [
   { label: "Sales", path: "/sales", icon: <SalesIcon /> },
   { label: "Products", path: "/products", icon: <ProductIcon /> },
   { label: "Deleted Customers", path: "/deleted-customers", icon: <TrashIcon /> },
-  { label: "Admin", path: "/admin", icon: <AdminIcon /> },
+  { label: "Admin", path: "/admin", icon: <AdminIcon />, title: "Admin Module — SUPERADMIN only" },
 ];
 
 export default function AppShell({ currentUser, onLogout = () => { }, children }) {
@@ -136,6 +136,7 @@ export default function AppShell({ currentUser, onLogout = () => { }, children }
                 key={path}
                 to={path}
                 onClick={() => setSidebarOpen(false)}
+                title={title}
                 style={({ isActive }) => ({
                   ...styles.navLink,
                   ...(isActive ? styles.navLinkActive : {}),


### PR DESCRIPTION
## What changed
- Verified that the Admin sidebar link is correctly gated by `rights.ADM_USER === 1`
  in `AppShell.jsx` — only SUPERADMIN can see it.
- Added a `title` prop to the Admin nav item to display a tooltip on hover:
  `"Admin Module — SUPERADMIN only"`.
- Updated the `NavLink` map destructure to pass `title` through to the rendered link.

## How to test
- Log in as **USER** → confirm Admin link is **not visible** in sidebar.
- Log in as **ADMIN** → confirm Admin link is **not visible** in sidebar.
- Log in as **SUPERADMIN** → confirm Admin link **is visible** in sidebar.
- Hover over the Admin link as SUPERADMIN → confirm tooltip reads
  `"Admin Module — SUPERADMIN only"`.

## Checklist
- [ ] Branched from `dev`
- [ ] App runs without errors
- [ ] No `.env` files committed
- [ ] No `console.log` in code