### PR TITLE
[S3-M4-02] feat/rights-superadmin-guard — SUPERADMIN Row Protection in UserManagementPage

### DIFF
--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -131,7 +131,7 @@ export default function AppShell({ currentUser, onLogout = () => { }, children }
           {/* Nav links */}
           <nav style={styles.nav} aria-label="Main navigation">
             <p style={styles.navSection}>Main Menu</p>
-            {visibleNavItems.map(({ label, path, icon }) => (
+            {visibleNavItems.map(({ label, path, icon, title }) => (
               <NavLink
                 key={path}
                 to={path}

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../context/AuthContext'
+import { activateUser, deactivateUser } from '../services/adminService'
 
 export default function AdminPage() {
   const { currentUser } = useAuth()
@@ -68,13 +69,10 @@ export default function AdminPage() {
   async function handleActivate(userId) {
     setActionLoading(userId)
     try {
-      await supabase
-        .from('user')
-        .update({ record_status: 'ACTIVE' })
-        .eq('userid', userId)
+      await activateUser(userId)
       await fetchUsers()
-    } catch {
-      alert('Failed to activate user.')
+    } catch (err) {
+      alert(err.message || 'Failed to activate user.')
     } finally {
       setActionLoading(null)
     }
@@ -83,13 +81,10 @@ export default function AdminPage() {
   async function handleDeactivate(userId) {
     setActionLoading(userId)
     try {
-      await supabase
-        .from('user')
-        .update({ record_status: 'INACTIVE' })
-        .eq('userid', userId)
+      await deactivateUser(userId)
       await fetchUsers()
-    } catch {
-      alert('Failed to deactivate user.')
+    } catch (err) {
+      alert(err.message || 'Failed to deactivate user.')
     } finally {
       setActionLoading(null)
     }


### PR DESCRIPTION
## What changed
- Wired `handleActivate()` and `handleDeactivate()` in `AdminPage.jsx` to use
  `activateUser()` and `deactivateUser()` from `adminService.js` instead of
  calling Supabase directly.
- SUPERADMIN guard is now enforced at the service layer — `adminService.js`
  throws an explicit error if a SUPERADMIN row is targeted before any
  Supabase call is made.
- Fixed `title` destructure in `AppShell.jsx` `.map()` from Issue 46 —
  `title` was added to the nav item but not destructured, causing a
  `ReferenceError` at runtime.
- SUPERADMIN rows in the user table render a disabled `Protected` button
  with tooltip `"SUPERADMIN accounts cannot be modified"` and a greyed-out
  `disabled-row` class — no Activate or Deactivate buttons are rendered.

## How to test
- Log in as **SUPERADMIN** → navigate to Admin Module.
- Confirm SUPERADMIN row shows `Protected` button — greyed out, not clickable.
- Hover over `Protected` button → confirm tooltip reads
  `"SUPERADMIN accounts cannot be modified"`.
- Attempt to activate or deactivate any non-SUPERADMIN user → confirm it works.
- Confirm `activateUser()` and `deactivateUser()` throw an error if called
  directly with a SUPERADMIN `userId`.

## Checklist
- [ ] Branched from `dev`
- [ ] App runs without errors
- [ ] No `.env` files committed
- [ ] No `console.log` in code