### PR TITLE
[S3-M1-03] chore/production-deploy — Vercel Deployment Configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## What changed
- Added `vercel.json` to the project root with a catch-all rewrite rule
  pointing all routes to `index.html`.
- This ensures React Router handles client-side routing correctly in
  production — without this, refreshing any route other than `/` returns
  a 404 from Vercel.

## How to test
- Open the live Vercel URL → confirm login page loads.
- Log in as **SUPERADMIN** → confirm redirect to `/customers` works.
- Manually navigate to `/products` in the browser address bar → confirm
  page loads without a 404.
- Refresh the page on any route → confirm it does not 404.

## Checklist
- [ ] Branched from `dev`
- [ ] App runs without errors
- [ ] No `.env` files committed
- [ ] No `console.log` in code