### PR TITLE
[S3-M2-01] Add UserManagementPage with SUPERADMIN row protection

### DIFF
--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
-import { supabase } from '../lib/supabase'
 import { useAuth } from '../context/AuthContext'
-import { activateUser, deactivateUser } from '../services/adminService'
+import { getUsers, activateUser, deactivateUser } from '../services/adminService'
 
 export default function AdminPage() {
   const { currentUser } = useAuth()
@@ -45,19 +44,19 @@ export default function AdminPage() {
     .ap-btn-disabled { padding: 5px 12px; border-radius: 6px; border: 1px solid #e5e7eb; font-size: 12px; font-weight: 500; cursor: not-allowed; background: #f9fafb; color: #9ca3af; }
     .ap-empty { text-align: center; padding: 56px 24px; color: #9ca3af; font-size: 13px; }
     .ap-footer { padding: 10px 14px; border-top: 1px solid #f3f4f6; font-size: 12px; color: #9ca3af; }
+    @media (max-width: 640px) {
+      .ap-page { padding: 16px; }
+      .ap-table th:nth-child(1), .ap-table td:nth-child(1) { display: none; }
+    }
   `
 
   async function fetchUsers() {
     setLoading(true)
     setError(null)
     try {
-      const { data, error } = await supabase
-        .from('user')
-        .select('*')
-        .order('user_type')
-      if (error) throw error
+      const data = await getUsers()
       setUsers(data || [])
-    } catch {
+    } catch (err) {
       setError('Failed to load users.')
     } finally {
       setLoading(false)
@@ -96,7 +95,11 @@ export default function AdminPage() {
   )
 
   function TypePill({ type }) {
-    const cls = type === 'SUPERADMIN' ? 'ap-type-super' : type === 'ADMIN' ? 'ap-type-admin' : 'ap-type-user'
+    const cls = type === 'SUPERADMIN'
+      ? 'ap-type-super'
+      : type === 'ADMIN'
+        ? 'ap-type-admin'
+        : 'ap-type-user'
     return <span className={`ap-type-pill ${cls}`}>{type}</span>
   }
 
@@ -111,14 +114,15 @@ export default function AdminPage() {
         </div>
 
         <div className="ap-notice">
-          SUPERADMIN accounts cannot be modified. Activate a new user after they register to grant them access.
+          SUPERADMIN accounts cannot be modified. Activate a new user after they
+          register to grant them access.
         </div>
 
         <div className="ap-controls">
           <input
             className="ap-search"
             type="text"
-            placeholder="Search by username or user ID…"
+            placeholder="Search by username or user ID..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
@@ -128,12 +132,14 @@ export default function AdminPage() {
           <div className="ap-card-header">
             <span className="ap-card-title">All Users</span>
             {!loading && (
-              <span className="ap-card-count">{filtered.length} user{filtered.length !== 1 ? 's' : ''}</span>
+              <span className="ap-card-count">
+                {filtered.length} user{filtered.length !== 1 ? 's' : ''}
+              </span>
             )}
           </div>
 
           {loading ? (
-            <div className="ap-empty">Loading users…</div>
+            <div className="ap-empty">Loading users...</div>
           ) : error ? (
             <div className="ap-empty" style={{ color: '#dc2626' }}>{error}</div>
           ) : filtered.length === 0 ? (
@@ -154,17 +160,20 @@ export default function AdminPage() {
                   {filtered.map((u) => {
                     const isSuperAdmin = u.user_type === 'SUPERADMIN'
                     const isActive = u.record_status === 'ACTIVE'
-                    const isCurrentUser = u.userid === (currentUser?.userid || currentUser?.id)
+                    const isCurrentUser = u.userid === currentUser?.userid
                     const isDisabled = isSuperAdmin || isCurrentUser
 
                     return (
                       <tr key={u.userid} className={isDisabled ? 'disabled-row' : ''}>
                         <td className="ap-mono">{u.userid}</td>
-                        <td style={{ fontWeight: 500 }}>{u.username || '—'}</td>
+                        <td style={{ fontWeight: 500 }}>{u.username || '-'}</td>
                         <td><TypePill type={u.user_type} /></td>
                         <td>
                           <span className={isActive ? 'ap-badge-active' : 'ap-badge-inactive'}>
-                            <span className="ap-badge-dot" style={{ background: isActive ? '#059669' : '#dc2626' }} />
+                            <span
+                              className="ap-badge-dot"
+                              style={{ background: isActive ? '#059669' : '#dc2626' }}
+                            />
                             {isActive ? 'Active' : 'Inactive'}
                           </span>
                         </td>
@@ -184,7 +193,7 @@ export default function AdminPage() {
                                   disabled={actionLoading === u.userid}
                                   onClick={() => handleActivate(u.userid)}
                                 >
-                                  {actionLoading === u.userid ? '…' : 'Activate'}
+                                  {actionLoading === u.userid ? '...' : 'Activate'}
                                 </button>
                               )}
                               {isActive && (
@@ -193,7 +202,7 @@ export default function AdminPage() {
                                   disabled={actionLoading === u.userid}
                                   onClick={() => handleDeactivate(u.userid)}
                                 >
-                                  {actionLoading === u.userid ? '…' : 'Deactivate'}
+                                  {actionLoading === u.userid ? '...' : 'Deactivate'}
                                 </button>
                               )}
                             </>

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -2,8 +2,8 @@ import { supabase } from '../lib/supabase';
 
 export async function getUsers() {
   const { data, error } = await supabase
-    .from('"user"')
-    .select('userId, username, email, user_type, record_status')
+    .from('user')
+    .select('userid, username, email, user_type, record_status')
     .order('user_type');
   if (error) throw error;
   return data;
@@ -11,9 +11,9 @@ export async function getUsers() {
 
 export async function activateUser(userId) {
   const { data: target, error: fetchError } = await supabase
-    .from('"user"')
+    .from('user')
     .select('user_type')
-    .eq('userId', userId)
+    .eq('userid', userId)
     .single();
 
   if (fetchError) throw fetchError;
@@ -22,17 +22,17 @@ export async function activateUser(userId) {
   }
 
   const { error } = await supabase
-    .from('"user"')
+    .from('user')
     .update({ record_status: 'ACTIVE' })
-    .eq('userId', userId);
+    .eq('userid', userId);
   if (error) throw error;
 }
 
 export async function deactivateUser(userId) {
   const { data: target, error: fetchError } = await supabase
-    .from('"user"')
+    .from('user')
     .select('user_type')
-    .eq('userId', userId)
+    .eq('userid', userId)
     .single();
 
   if (fetchError) throw fetchError;
@@ -41,8 +41,8 @@ export async function deactivateUser(userId) {
   }
 
   const { error } = await supabase
-    .from('"user"')
+    .from('user')
     .update({ record_status: 'INACTIVE' })
-    .eq('userId', userId);
+    .eq('userid', userId);
   if (error) throw error;
 }


### PR DESCRIPTION
## What changed
- Updated AdminPage.jsx to use getUsers(), activateUser(), and 
  deactivateUser() from M1's adminService.js instead of calling 
  Supabase directly
- Fixed adminService.js: removed extra quotes from table name 
  '"user"' → 'user' and corrected column name 'userId' → 'userid' 
  to match actual database column casing
- SUPERADMIN rows are fully disabled with a 'Protected' label and 
  tooltip: 'SUPERADMIN accounts cannot be modified'
- Currently logged-in user's own row is also protected
- Activate/Deactivate buttons work correctly and refresh the table 
  after each action
- Search filters by username or user ID in real time
- Added mobile responsive rule hiding User ID column on small screens

## How to test
1. Log in as SUPERADMIN — navigate to Admin page
2. Confirm SUPERADMIN row shows Protected and is dimmed
3. Click Deactivate on any USER row — confirm status changes to Inactive
4. Click Activate on that same row — confirm status returns to Active
5. Type in the search bar — confirm table filters in real time

## Branch
feat/ui-admin-users → dev

