### PR TITLE
[S3-M2-02] Add CustomerSalesSummaryPage, TopCustomersPage, and ProductRevenuePage with Reports sidebar links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,9 @@ import CustomersPage from './pages/CustomersPage'
 import SalesPage from './pages/SalesPage'
 import ProductsPage from './pages/ProductsPage'
 import AdminPage from './pages/AdminPage'
+import CustomerSalesSummaryPage from './pages/CustomerSalesSummaryPage'
+import TopCustomersPage from './pages/TopCustomersPage'
+import ProductRevenuePage from './pages/ProductRevenuePage'
 import DeletedCustomersPage from './pages/DeletedCustomersPage'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -130,6 +133,9 @@ export default function App() {
               <Route path="/sales" element={<SalesPage />} />
               <Route path="/products" element={<ProductsPage />} />
               <Route path="/admin" element={<AdminPage />} />
+              <Route path="/reports/customer-sales" element={<CustomerSalesSummaryPage />} />
+              <Route path="/reports/top-customers" element={<TopCustomersPage />} />
+              <Route path="/reports/product-revenue" element={<ProductRevenuePage />} />
             </Route>
 
             {/* ── Admin-only routes — ADMIN and SUPERADMIN only ───────── */}

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -24,6 +24,9 @@ const NAV_ITEMS = [
   { label: "Sales", path: "/sales", icon: <SalesIcon /> },
   { label: "Products", path: "/products", icon: <ProductIcon /> },
   { label: "Deleted Customers", path: "/deleted-customers", icon: <TrashIcon /> },
+  { label: "Customer Sales Summary", path: "/reports/customer-sales", icon: <ReportIcon />, section: "Reports" },
+  { label: "Top Customers", path: "/reports/top-customers", icon: <ReportIcon />, section: "Reports" },
+  { label: "Product Revenue", path: "/reports/product-revenue", icon: <ReportIcon />, section: "Reports" },
   { label: "Admin", path: "/admin", icon: <AdminIcon />, title: "Admin Module — SUPERADMIN only" },
 ];
 
@@ -131,12 +134,27 @@ export default function AppShell({ currentUser, onLogout = () => { }, children }
           {/* Nav links */}
           <nav style={styles.nav} aria-label="Main navigation">
             <p style={styles.navSection}>Main Menu</p>
-            {visibleNavItems.map(({ label, path, icon, title }) => (
+            {visibleNavItems.filter(i => !i.section).map(({ label, path, icon, title }) => (
               <NavLink
                 key={path}
                 to={path}
                 onClick={() => setSidebarOpen(false)}
                 title={title}
+                style={({ isActive }) => ({
+                  ...styles.navLink,
+                  ...(isActive ? styles.navLinkActive : {}),
+                })}
+              >
+                <span style={styles.navIcon}>{icon}</span>
+                {label}
+              </NavLink>
+            ))}
+            <p style={styles.navSection}>Reports</p>
+            {visibleNavItems.filter(i => i.section === 'Reports').map(({ label, path, icon }) => (
+              <NavLink
+                key={path}
+                to={path}
+                onClick={() => setSidebarOpen(false)}
                 style={({ isActive }) => ({
                   ...styles.navLink,
                   ...(isActive ? styles.navLinkActive : {}),
@@ -267,6 +285,17 @@ function LogoutIcon() {
   );
 }
 
+function ReportIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="16" y1="13" x2="8" y2="13" />
+      <line x1="16" y1="17" x2="8" y2="17" />
+      <polyline points="10 9 9 9 8 9" />
+    </svg>
+  );
+}
 // ── Inline styles (no @media rules here) ─────────────────────────
 const BLUE = "#2563eb";
 

--- a/src/pages/CustomerSalesSummaryPage.jsx
+++ b/src/pages/CustomerSalesSummaryPage.jsx
@@ -1,0 +1,159 @@
+import { useState, useEffect } from 'react'
+import { getCustomerSalesSummary } from '../services/reportsService'
+
+export default function CustomerSalesSummaryPage() {
+  const [data, setData] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [search, setSearch] = useState('')
+  const [sortField, setSortField] = useState('totalSpend')
+  const [sortAsc, setSortAsc] = useState(false)
+
+  const css = `
+    .cs-page { padding: 28px 32px; max-width: 1100px; margin: 0 auto; font-family: sans-serif; }
+    .cs-topbar { margin-bottom: 24px; }
+    .cs-title { font-size: 22px; font-weight: 600; margin: 0 0 4px; color: #111827; }
+    .cs-sub { font-size: 13px; color: #6b7280; margin: 0; }
+    .cs-controls { display: flex; gap: 10px; margin-bottom: 20px; flex-wrap: wrap; }
+    .cs-search { flex: 1; min-width: 200px; padding: 9px 14px; border: 1px solid #e5e7eb; border-radius: 8px; font-size: 13px; color: #111827; outline: none; }
+    .cs-search:focus { border-color: #93c5fd; box-shadow: 0 0 0 3px rgba(59,130,246,0.1); }
+    .cs-card { background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden; }
+    .cs-card-header { padding: 14px 18px; border-bottom: 1px solid #f3f4f6; background: #f9fafb; display: flex; justify-content: space-between; align-items: center; }
+    .cs-card-title { font-size: 13px; font-weight: 600; color: #374151; margin: 0; }
+    .cs-card-count { font-size: 12px; color: #9ca3af; }
+    .cs-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    .cs-table th { padding: 10px 14px; text-align: left; font-size: 11px; font-weight: 600; color: #6b7280; border-bottom: 1px solid #f3f4f6; text-transform: uppercase; letter-spacing: 0.05em; background: #f9fafb; white-space: nowrap; cursor: pointer; user-select: none; }
+    .cs-table th:hover { background: #f3f4f6; color: #374151; }
+    .cs-table td { padding: 11px 14px; border-bottom: 1px solid #f9fafb; color: #111827; vertical-align: middle; }
+    .cs-table tr:last-child td { border-bottom: none; }
+    .cs-table tbody tr:hover td { background: #f9fafb; }
+    .cs-mono { font-family: monospace; font-size: 12px; color: #6b7280; }
+    .cs-empty { text-align: center; padding: 56px 24px; color: #9ca3af; font-size: 13px; }
+    .cs-footer { padding: 10px 14px; border-top: 1px solid #f3f4f6; font-size: 12px; color: #9ca3af; }
+    .cs-spend { font-weight: 600; color: #059669; }
+    @media (max-width: 640px) {
+      .cs-page { padding: 16px; }
+      .cs-table th:nth-child(1), .cs-table td:nth-child(1) { display: none; }
+    }
+  `
+
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true)
+      setError(null)
+      try {
+        const result = await getCustomerSalesSummary()
+        setData(result || [])
+      } catch (err) {
+        setError('Failed to load customer sales summary.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  function handleSort(field) {
+    if (sortField === field) {
+      setSortAsc(!sortAsc)
+    } else {
+      setSortField(field)
+      setSortAsc(false)
+    }
+  }
+
+  function sortArrow(field) {
+    if (sortField !== field) return ' ↕'
+    return sortAsc ? ' ↑' : ' ↓'
+  }
+
+  const filtered = data
+    .filter((r) => r.custname?.toLowerCase().includes(search.toLowerCase()))
+    .sort((a, b) => {
+      const av = a[sortField] ?? 0
+      const bv = b[sortField] ?? 0
+      if (typeof av === 'string') return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av)
+      return sortAsc ? av - bv : bv - av
+    })
+
+  function formatCurrency(val) {
+    if (val == null) return '—'
+    return '₱' + Number(val).toLocaleString('en-PH', { minimumFractionDigits: 2 })
+  }
+
+  function formatDate(val) {
+    if (!val) return '—'
+    return new Date(val).toLocaleDateString('en-PH', { year: 'numeric', month: 'short', day: 'numeric' })
+  }
+
+  return (
+    <>
+      <style>{css}</style>
+      <div className="cs-page">
+
+        <div className="cs-topbar">
+          <h1 className="cs-title">Customer Sales Summary</h1>
+          <p className="cs-sub">Total transactions and spend per customer — read only</p>
+        </div>
+
+        <div className="cs-controls">
+          <input
+            className="cs-search"
+            type="text"
+            placeholder="Search by customer name..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+
+        <div className="cs-card">
+          <div className="cs-card-header">
+            <span className="cs-card-title">All Customers</span>
+            {!loading && (
+              <span className="cs-card-count">
+                {filtered.length} customer{filtered.length !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+
+          {loading ? (
+            <div className="cs-empty">Loading...</div>
+          ) : error ? (
+            <div className="cs-empty" style={{ color: '#dc2626' }}>{error}</div>
+          ) : filtered.length === 0 ? (
+            <div className="cs-empty">No customers found.</div>
+          ) : (
+            <>
+              <table className="cs-table">
+                <thead>
+                  <tr>
+                    <th onClick={() => handleSort('custno')}>Cust No{sortArrow('custno')}</th>
+                    <th onClick={() => handleSort('custname')}>Customer Name{sortArrow('custname')}</th>
+                    <th onClick={() => handleSort('totalTransactions')}>Transactions{sortArrow('totalTransactions')}</th>
+                    <th onClick={() => handleSort('totalSpend')}>Total Spend{sortArrow('totalSpend')}</th>
+                    <th onClick={() => handleSort('lastSaleDate')}>Last Sale{sortArrow('lastSaleDate')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((r) => (
+                    <tr key={r.custno}>
+                      <td className="cs-mono">{r.custno}</td>
+                      <td style={{ fontWeight: 500 }}>{r.custname}</td>
+                      <td>{r.totalTransactions ?? 0}</td>
+                      <td className="cs-spend">{formatCurrency(r.totalSpend)}</td>
+                      <td>{formatDate(r.lastSaleDate)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div className="cs-footer">
+                Showing {filtered.length} of {data.length} customers
+              </div>
+            </>
+          )}
+        </div>
+
+      </div>
+    </>
+  )
+}

--- a/src/pages/ProductRevenuePage.jsx
+++ b/src/pages/ProductRevenuePage.jsx
@@ -1,0 +1,163 @@
+import { useState, useEffect } from 'react'
+import { getProductRevenue } from '../services/reportsService'
+
+export default function ProductRevenuePage() {
+  const [data, setData] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [search, setSearch] = useState('')
+  const [sortField, setSortField] = useState('totalRevenue')
+  const [sortAsc, setSortAsc] = useState(false)
+
+  const css = `
+    .pr-page { padding: 28px 32px; max-width: 1100px; margin: 0 auto; font-family: sans-serif; }
+    .pr-topbar { margin-bottom: 24px; }
+    .pr-title { font-size: 22px; font-weight: 600; margin: 0 0 4px; color: #111827; }
+    .pr-sub { font-size: 13px; color: #6b7280; margin: 0; }
+    .pr-notice { background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 8px; padding: 10px 14px; margin-bottom: 20px; font-size: 13px; color: #166534; }
+    .pr-controls { margin-bottom: 20px; }
+    .pr-search { width: 100%; box-sizing: border-box; padding: 9px 14px; border: 1px solid #e5e7eb; border-radius: 8px; font-size: 13px; color: #111827; outline: none; }
+    .pr-search:focus { border-color: #93c5fd; box-shadow: 0 0 0 3px rgba(59,130,246,0.1); }
+    .pr-card { background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden; }
+    .pr-card-header { padding: 14px 18px; border-bottom: 1px solid #f3f4f6; background: #f9fafb; display: flex; justify-content: space-between; align-items: center; }
+    .pr-card-title { font-size: 13px; font-weight: 600; color: #374151; margin: 0; }
+    .pr-card-count { font-size: 12px; color: #9ca3af; }
+    .pr-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    .pr-table th { padding: 10px 14px; text-align: left; font-size: 11px; font-weight: 600; color: #6b7280; border-bottom: 1px solid #f3f4f6; text-transform: uppercase; letter-spacing: 0.05em; background: #f9fafb; white-space: nowrap; cursor: pointer; user-select: none; }
+    .pr-table th:hover { background: #f3f4f6; color: #374151; }
+    .pr-table td { padding: 11px 14px; border-bottom: 1px solid #f9fafb; color: #111827; vertical-align: middle; }
+    .pr-table tr:last-child td { border-bottom: none; }
+    .pr-table tbody tr:hover td { background: #f9fafb; }
+    .pr-mono { font-family: monospace; font-size: 12px; color: #6b7280; }
+    .pr-badge { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 11px; font-weight: 600; background: #e0e7ff; color: #3730a3; border: 1px solid #c7d2fe; }
+    .pr-revenue { font-weight: 600; color: #059669; }
+    .pr-empty { text-align: center; padding: 56px 24px; color: #9ca3af; font-size: 13px; }
+    .pr-footer { padding: 10px 14px; border-top: 1px solid #f3f4f6; font-size: 12px; color: #9ca3af; }
+    @media (max-width: 640px) {
+      .pr-page { padding: 16px; }
+      .pr-table th:nth-child(1), .pr-table td:nth-child(1) { display: none; }
+    }
+  `
+
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true)
+      setError(null)
+      try {
+        const result = await getProductRevenue()
+        setData(result || [])
+      } catch {
+        setError('Failed to load product revenue.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  function handleSort(field) {
+    if (sortField === field) {
+      setSortAsc(!sortAsc)
+    } else {
+      setSortField(field)
+      setSortAsc(false)
+    }
+  }
+
+  function sortArrow(field) {
+    if (sortField !== field) return ' ↕'
+    return sortAsc ? ' ↑' : ' ↓'
+  }
+
+  const filtered = data
+    .filter((r) =>
+      r.description?.toLowerCase().includes(search.toLowerCase()) ||
+      r.prodcode?.toLowerCase().includes(search.toLowerCase())
+    )
+    .sort((a, b) => {
+      const av = a[sortField] ?? 0
+      const bv = b[sortField] ?? 0
+      if (typeof av === 'string') return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av)
+      return sortAsc ? av - bv : bv - av
+    })
+
+  function formatCurrency(val) {
+    if (val == null) return '—'
+    return '₱' + Number(val).toLocaleString('en-PH', { minimumFractionDigits: 2 })
+  }
+
+  return (
+    <>
+      <style>{css}</style>
+      <div className="pr-page">
+
+        <div className="pr-topbar">
+          <h1 className="pr-title">Product Revenue</h1>
+          <p className="pr-sub">Total quantity sold and revenue per product — read only</p>
+        </div>
+
+        <div className="pr-notice">
+          This page is view-only. No add, edit, or delete operations are available.
+        </div>
+
+        <div className="pr-controls">
+          <input
+            className="pr-search"
+            type="text"
+            placeholder="Search by product code or description..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+
+        <div className="pr-card">
+          <div className="pr-card-header">
+            <span className="pr-card-title">All Products</span>
+            {!loading && (
+              <span className="pr-card-count">
+                {filtered.length} product{filtered.length !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+
+          {loading ? (
+            <div className="pr-empty">Loading...</div>
+          ) : error ? (
+            <div className="pr-empty" style={{ color: '#dc2626' }}>{error}</div>
+          ) : filtered.length === 0 ? (
+            <div className="pr-empty">No products found.</div>
+          ) : (
+            <>
+              <table className="pr-table">
+                <thead>
+                  <tr>
+                    <th onClick={() => handleSort('prodcode')}>Prod Code{sortArrow('prodcode')}</th>
+                    <th onClick={() => handleSort('description')}>Description{sortArrow('description')}</th>
+                    <th onClick={() => handleSort('unit')}>Unit{sortArrow('unit')}</th>
+                    <th onClick={() => handleSort('totalQtySold')}>Qty Sold{sortArrow('totalQtySold')}</th>
+                    <th onClick={() => handleSort('totalRevenue')}>Total Revenue{sortArrow('totalRevenue')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((r) => (
+                    <tr key={r.prodcode}>
+                      <td className="pr-mono">{r.prodcode}</td>
+                      <td style={{ fontWeight: 500 }}>{r.description}</td>
+                      <td><span className="pr-badge">{r.unit}</span></td>
+                      <td>{r.totalQtySold ?? 0}</td>
+                      <td className="pr-revenue">{formatCurrency(r.totalRevenue)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div className="pr-footer">
+                Showing {filtered.length} of {data.length} products
+              </div>
+            </>
+          )}
+        </div>
+
+      </div>
+    </>
+  )
+}

--- a/src/pages/TopCustomersPage.jsx
+++ b/src/pages/TopCustomersPage.jsx
@@ -1,0 +1,128 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getTopCustomers } from '../services/reportsService'
+
+export default function TopCustomersPage() {
+  const [data, setData] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const navigate = useNavigate()
+
+  const css = `
+    .tc-page { padding: 28px 32px; max-width: 1100px; margin: 0 auto; font-family: sans-serif; }
+    .tc-topbar { margin-bottom: 24px; }
+    .tc-title { font-size: 22px; font-weight: 600; margin: 0 0 4px; color: #111827; }
+    .tc-sub { font-size: 13px; color: #6b7280; margin: 0; }
+    .tc-card { background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden; margin-bottom: 24px; }
+    .tc-card-header { padding: 14px 18px; border-bottom: 1px solid #f3f4f6; background: #f9fafb; display: flex; justify-content: space-between; align-items: center; }
+    .tc-card-title { font-size: 13px; font-weight: 600; color: #374151; margin: 0; }
+    .tc-card-sub { font-size: 12px; color: #9ca3af; margin: 0; }
+    .tc-list { padding: 12px 0; }
+    .tc-row { display: flex; align-items: center; gap: 16px; padding: 12px 18px; border-bottom: 1px solid #f9fafb; cursor: pointer; transition: background 0.15s; }
+    .tc-row:last-child { border-bottom: none; }
+    .tc-row:hover { background: #f9fafb; }
+    .tc-rank { width: 28px; height: 28px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 700; flex-shrink: 0; }
+    .tc-rank-1 { background: #fef3c7; color: #92400e; }
+    .tc-rank-2 { background: #f3f4f6; color: #374151; }
+    .tc-rank-3 { background: #fef3c7; color: #b45309; }
+    .tc-rank-other { background: #f3f4f6; color: #6b7280; }
+    .tc-info { flex: 1; min-width: 0; }
+    .tc-name { font-size: 13px; font-weight: 600; color: #111827; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tc-meta { font-size: 12px; color: #9ca3af; margin-top: 2px; }
+    .tc-spend { font-size: 14px; font-weight: 700; color: #059669; flex-shrink: 0; }
+    .tc-bar-wrap { width: 120px; flex-shrink: 0; }
+    .tc-bar-bg { background: #f3f4f6; border-radius: 9999px; height: 6px; overflow: hidden; }
+    .tc-bar-fill { height: 6px; border-radius: 9999px; background: linear-gradient(90deg, #10b981, #059669); }
+    .tc-empty { text-align: center; padding: 56px 24px; color: #9ca3af; font-size: 13px; }
+    @media (max-width: 640px) {
+      .tc-page { padding: 16px; }
+      .tc-bar-wrap { display: none; }
+    }
+  `
+
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true)
+      setError(null)
+      try {
+        const result = await getTopCustomers()
+        setData(result || [])
+      } catch {
+        setError('Failed to load top customers.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  function formatCurrency(val) {
+    if (val == null) return '—'
+    return '₱' + Number(val).toLocaleString('en-PH', { minimumFractionDigits: 2 })
+  }
+
+  const maxSpend = data.length > 0 ? Math.max(...data.map((r) => r.totalSpend ?? 0)) : 1
+
+  function rankClass(i) {
+    if (i === 0) return 'tc-rank tc-rank-1'
+    if (i === 1) return 'tc-rank tc-rank-2'
+    if (i === 2) return 'tc-rank tc-rank-3'
+    return 'tc-rank tc-rank-other'
+  }
+
+  return (
+    <>
+      <style>{css}</style>
+      <div className="tc-page">
+
+        <div className="tc-topbar">
+          <h1 className="tc-title">Top Customers</h1>
+          <p className="tc-sub">Top 10 customers ranked by total spend — click a row to view details</p>
+        </div>
+
+        <div className="tc-card">
+          <div className="tc-card-header">
+            <span className="tc-card-title">Leaderboard</span>
+            <span className="tc-card-sub">Top {data.length} customers by spend</span>
+          </div>
+
+          {loading ? (
+            <div className="tc-empty">Loading...</div>
+          ) : error ? (
+            <div className="tc-empty" style={{ color: '#dc2626' }}>{error}</div>
+          ) : data.length === 0 ? (
+            <div className="tc-empty">No data available.</div>
+          ) : (
+            <div className="tc-list">
+              {data.map((r, i) => (
+                <div
+                  key={r.custno}
+                  className="tc-row"
+                  onClick={() => navigate(`/customers/${r.custno}`)}
+                >
+                  <div className={rankClass(i)}>
+                    {i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : i + 1}
+                  </div>
+                  <div className="tc-info">
+                    <div className="tc-name">{r.custname}</div>
+                    <div className="tc-meta">{r.totalTransactions} transaction{r.totalTransactions !== 1 ? 's' : ''}</div>
+                  </div>
+                  <div className="tc-bar-wrap">
+                    <div className="tc-bar-bg">
+                      <div
+                        className="tc-bar-fill"
+                        style={{ width: `${((r.totalSpend ?? 0) / maxSpend) * 100}%` }}
+                      />
+                    </div>
+                  </div>
+                  <div className="tc-spend">{formatCurrency(r.totalSpend)}</div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+      </div>
+    </>
+  )
+}

--- a/src/services/reportsService.js
+++ b/src/services/reportsService.js
@@ -22,8 +22,7 @@ export async function getTopCustomers() {
 export async function getProductRevenue() {
   const { data, error } = await supabase
     .from('product_revenue')
-    .select('prodCode, description, unit, totalQtySold, totalRevenue')
-    .order('totalRevenue', { ascending: false });
+    .select('*')
   if (error) throw error;
   return data;
 }


### PR DESCRIPTION
## What changed
- Created CustomerSalesSummaryPage: sortable table showing custno, 
  customer name, transaction count, total spend (₱ formatted), 
  and last sale date; searchable by customer name
- Created TopCustomersPage: leaderboard of top 10 customers by 
  total spend with rank medals, spend bars, and clickable rows 
  that navigate to CustomerDetailPage
- Created ProductRevenuePage: sortable table showing product code, 
  description, unit, total qty sold, and total revenue (₱ formatted);
  searchable by product code or description; view-only with no 
  mutation controls
- Added Reports section to AppShell sidebar with links to all 3 
  report pages and a ReportIcon
- Added 3 new routes to App.jsx:
  /reports/customer-sales
  /reports/top-customers
  /reports/product-revenue
- Fixed reportsService.js getProductRevenue(): removed .order() 
  and changed to select('*') to match actual Supabase view schema
- Fixed ProductRevenuePage column references to use lowercase 
  prodcode to match actual database column casing

## How to test
1. Log in and check the sidebar — Reports section should show 
   3 links: Customer Sales Summary, Top Customers, Product Revenue
2. Navigate to /reports/customer-sales — confirm table loads with 
   sortable columns and search works
3. Navigate to /reports/top-customers — confirm top 10 leaderboard 
   loads with medals and spend bars; click a row to go to 
   CustomerDetailPage
4. Navigate to /reports/product-revenue — confirm table loads with 
   sortable columns and search works; confirm no add/edit/delete 
   buttons exist

## Branch
feat/ui-reports → dev
